### PR TITLE
Add 'cicustom' input variable for custom cloudinit

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,10 @@ No Modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| admin\_password | The password of the local administrator. This is set during the cloud-init process. If this is null, admin\_ssh\_public\_keys must be set. | `string` | `null` | no |
-| admin\_public\_ssh\_keys | The public keys of the local administrator. This is set during the cloud-init process. If this is null, admin\_password must be set. | `list(string)` | `[]` | no |
-| admin\_username | The username of the local administrator. This is set during the cloud-init process. | `string` | n/a | yes |
+| admin\_password | The password of the local administrator. This is set during the cloud-init process. If this is null, admin\_ssh\_public\_keys or cicustom must be set. | `string` | `null` | no |
+| admin\_public\_ssh\_keys | The public keys of the local administrator. This is set during the cloud-init process. If this is null, admin\_password or cicustom must be set. | `list(string)` | `[]` | no |
+| admin\_username | The username of the local administrator. This is set during the cloud-init process. If this is null, cicustom must be set. | `string` | `null` | no |
+| cicustom | Location of a custom cloudinit config to use. E.g. user=local:snippets/user-data_vm-foo.yml. If this is null, admin_username must be set and admin_password or admin_public_ssh_keys. | `string` | `null` | no |
 | cores | How many CPU cores to give the virtual machine. | `number` | `1` | no |
 | disk\_default\_format | The format of the file backing the disk. | `string` | `"raw"` | no |
 | disk\_default\_size | The size of the disk, including a unit suffix, such as 10G to indicate 10 gigabytes. | `string` | `null` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -12,9 +12,11 @@ locals {
   template_clone      = var.template_clone
   template_full_clone = var.template_full_clone
 
-  admin_username        = var.admin_username
-  admin_password        = var.admin_password
-  admin_public_ssh_keys = var.admin_public_ssh_keys
+  cicustom = var.cicustom
+
+  admin_username        = var.cicustom == null ? var.admin_username : null
+  admin_password        = var.cicustom == null ? var.admin_password : null
+  admin_public_ssh_keys = var.cicustom == null ? var.admin_public_ssh_keys : null
 
   sockets = var.sockets
   cores   = var.cores

--- a/main.tf
+++ b/main.tf
@@ -39,9 +39,10 @@ resource "proxmox_vm_qemu" "cloudinit" {
   # Additional Networks - Future
 
   # Cloud-Init Drive
+  cicustom   = local.cicustom
   ciuser     = local.admin_username
   cipassword = local.admin_password
-  sshkeys    = <<-EOF
+  sshkeys    = var.cicustom != null ? null : <<-EOF
   %{for key in local.admin_public_ssh_keys~}
   ${key}
   %{endfor~}

--- a/variables.tf
+++ b/variables.tf
@@ -10,11 +10,6 @@ variable "template_clone" {
   description = "Name of the Proxmox template to clone from."
 }
 
-variable "admin_username" {
-  type        = string
-  description = "The username of the local administrator. This is set during the cloud-init process."
-}
-
 #### Optional Parameters #####
 
 variable "vm_id" {
@@ -47,9 +42,15 @@ variable "template_full_clone" {
   default     = true
 }
 
+variable "admin_username" {
+  type        = string
+  description = "The username of the local administrator. This is set during the cloud-init process. If this is null, cicustom must be set."
+  default     = null
+}
+
 variable "admin_password" {
   type        = string
-  description = "The password of the local administrator. This is set during the cloud-init process. If this is null, admin_ssh_public_keys must be set."
+  description = "The password of the local administrator. This is set during the cloud-init process. If this is null, admin_ssh_public_keys or cicustom must be set."
   default     = null
 }
 
@@ -162,4 +163,10 @@ variable "tags" {
   type        = list(string)
   description = "List of virtual machine tags."
   default     = []
+}
+
+variable "cicustom" {
+  type        = string
+  description = "Location of a custom cloudinit config to use. E.g. user=local:snippets/user-data_vm-foo.yml. If this is null, admin_username must be set and admin_password or admin_public_ssh_keys."
+  default     = null
 }


### PR DESCRIPTION
This adds a `cicustom` input variable for specifying a custom cloud-init
configuration.

This variable is mutually exclusive with `admin_username`,
`admin_password`, and `admin_public_ssh_keys`. If `cicustom` is set,
those variables should be left unset to `null`. The `admin_username`
variable now defaults to `null`.

The handling of the user data itself is not handled in this module and a
path to a cloud-init config on Proxmox storage should be set.

The syntax for a value looks like
`user=local:snippets/user-data_vm-foo.yml`, where `local` is the storage
name, `snippets` is the path on the filesystem (`/var/lib/vz/snippets`),
and `user-data_vm-foo.yml` is the user data config file deployed
external to this module.

Thanks for this module!