### PR TITLE
Add 'vm_bootdisk' and 'vm_qemu_os' variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ No Modules.
 | tags | List of virtual machine tags. | `list(string)` | `[]` | no |
 | template\_clone | Name of the Proxmox template to clone from. | `string` | n/a | yes |
 | template\_full\_clone | Performs a full clone of the template when enabled. | `bool` | `true` | no |
+| vm\_boot\_disk | Enable booting from specified disk. You shouldn't need to change this under most circumstances. | `string` | `null` | no |
 | vm\_boot\_order | The boot order for the VM. Proxmox 6.2 changed boot order text from 'cdn'. | `string` | `""` | no |
 | vm\_description | The virtual machine description. | `string` | `null` | no |
 | vm\_id | The ID of the virtual machine. If not set, the next available ID will be used. | `number` | `null` | no |

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ No Modules.
 | vm\_description | The virtual machine description. | `string` | `null` | no |
 | vm\_id | The ID of the virtual machine. If not set, the next available ID will be used. | `number` | `null` | no |
 | vm\_name | The virtual machine name. | `string` | n/a | yes |
+| vm\_qemu\_os | The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS. It takes the value from the source template and ignore any changes to resource configuration parameter. | `string` | `null` | no |
 | vm\_start\_on\_boot | Specifies whether a VM will be started during system bootup. | `bool` | `false` | no |
 
 ## Outputs

--- a/locals.tf
+++ b/locals.tf
@@ -9,6 +9,7 @@ locals {
   vm_start_on_boot = var.vm_start_on_boot
   vm_boot_order    = var.vm_boot_order != null ? var.vm_boot_order : ""
   vm_boot_disk     = var.vm_boot_disk
+  vm_qemu_os       = var.vm_qemu_os
 
   template_clone      = var.template_clone
   template_full_clone = var.template_full_clone

--- a/locals.tf
+++ b/locals.tf
@@ -8,6 +8,7 @@ locals {
   vm_description   = var.vm_description
   vm_start_on_boot = var.vm_start_on_boot
   vm_boot_order    = var.vm_boot_order != null ? var.vm_boot_order : ""
+  vm_boot_disk     = var.vm_boot_disk
 
   template_clone      = var.template_clone
   template_full_clone = var.template_full_clone

--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,7 @@ resource "proxmox_vm_qemu" "cloudinit" {
   desc     = local.vm_description
   vmid     = local.vm_id
   os_type  = "cloud-init"
+  qemu_os  = local.vm_qemu_os
   agent    = 1
   onboot   = local.vm_start_on_boot
   boot     = local.vm_boot_order

--- a/main.tf
+++ b/main.tf
@@ -1,13 +1,14 @@
 
 /* Uses cloud-init options from Proxmox 5.2 onward */
 resource "proxmox_vm_qemu" "cloudinit" {
-  name    = local.vm_name
-  desc    = local.vm_description
-  vmid    = local.vm_id
-  os_type = "cloud-init"
-  agent   = 1
-  onboot  = local.vm_start_on_boot
-  boot    = local.vm_boot_order
+  name     = local.vm_name
+  desc     = local.vm_description
+  vmid     = local.vm_id
+  os_type  = "cloud-init"
+  agent    = 1
+  onboot   = local.vm_start_on_boot
+  boot     = local.vm_boot_order
+  bootdisk = local.vm_boot_disk
 
   target_node = local.proxmox_node
   pool        = local.proxmox_resource_pool

--- a/variables.tf
+++ b/variables.tf
@@ -169,3 +169,9 @@ variable "tags" {
   description = "List of virtual machine tags."
   default     = []
 }
+
+variable "vm_qemu_os" {
+  type        = string
+  description = "The type of OS in the guest. Set properly to allow Proxmox to enable optimizations for the appropriate guest OS."
+  default     = null
+}

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "vm_boot_order" {
   default     = ""
 }
 
+variable "vm_boot_disk" {
+  description = "Enable booting from specified disk. You shouldn't need to change this under most circumstances."
+  type        = string
+  default     = null
+}
+
 variable "template_full_clone" {
   type        = bool
   description = "Performs a full clone of the template when enabled."


### PR DESCRIPTION
[Add 'vm_bootdisk' input variable](https://github.com/sdhibit/terraform-proxmox-cloud-init-vm/commit/bb4c620c99c0f975d27eb7ca7bf5c8a9877563a7)

This adds a `vm_bootdisk` input variable for customizing the boot disk.

From the provider docs:

> Enable booting from specified disk. You shouldn't need to change it
  under most circumstances.

---

[Add 'vm_qemu_os' input variable](https://github.com/sdhibit/terraform-proxmox-cloud-init-vm/commit/2ac9ee2becfd308afd8fe444fe1c2fd823f603f5)

This adds a `vm_qemu_os` input variable.

From the provider docs:

> The type of OS in the guest. Set properly to allow Proxmox to enable
  optimizations for the appropriate guest OS. It takes the value from the
  source template and ignore any changes to resource configuration
  parameter.